### PR TITLE
fix cli command to publish update (token is not always required)

### DIFF
--- a/setup/__version__.py
+++ b/setup/__version__.py
@@ -7,7 +7,7 @@ changes to your authorization policies and pushes live updates to your policy ag
 Project homepage: https://github.com/authorizon/opal
 """
 
-VERSION = (0, 1, 2)
+VERSION = (0, 1, 3)
 VERSION_STRING = '.'.join(map(str,VERSION))
 
 __version__ = VERSION_STRING


### PR DESCRIPTION
test plan:
```
❯ opal-client publish-data-update secret --src-url https://api.country.is/23.54.6.78 -t policy_data --dst-path /users/bob/location

Publishing event:
entries=[DataSourceEntry(url='https://api.country.is/23.54.6.78', config={}, topics=['policy_data'], dst_path='/users/bob/location', save_method='PUT')] reason=''
Event Published Successfully

❯ opal-client publish-data-update --src-url https://api.country.is/23.54.6.78 -t policy_data --dst-path /users/bob/location

Publishing event:
entries=[DataSourceEntry(url='https://api.country.is/23.54.6.78', config={}, topics=['policy_data'], dst_path='/users/bob/location', save_method='PUT')] reason=''
Event Published Successfully
```