### PR TITLE
Fix on_release workflow

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -7,13 +7,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  # this job builds the docker images locally on the workflow runner machine
-  # it then runs a modified docker compose and tests the output of an OPA query
-  # the output will only be as expect if the OPAL client managed to connect to
-  # OPAL server and to download the data and policy successfully.
-  # this job also outputs the docker compose logs so it's easy to understand
-  # what went wrong in case of error.
-  docker_build_and_test:
+  # this job will build and push the docker images to docker hub
+  # - it will only run after a new "release" is create on github
+  # - it will auto tag the image according to the github release tag
+  docker_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,26 +22,52 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
-
       - name: Build client
         id: build_client
-        run: docker build -t authorizon/opal-client:test --target client -f docker/Dockerfile .
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: client
+          cache-from: type=registry,ref=authorizon/opal-client:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-client:test
+            authorizon/opal-client:latest
+            authorizon/opal-client:${{ github.event.release.tag_name }}
 
       - name: Build client-standalone
         id: build_client_standalone
-        run: docker build -t authorizon/opal-client-standalone:test --target client-standalone -f docker/Dockerfile .
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: client-standalone
+          cache-from: type=registry,ref=authorizon/opal-client-standalone:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-client-standalone:test
+            authorizon/opal-client-standalone:latest
+            authorizon/opal-client-standalone:${{ github.event.release.tag_name }}
 
       - name: Build server
         id: build_server
-        run: docker build -t authorizon/opal-server:test --target server -f docker/Dockerfile .
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile
+          push: false
+          target: server
+          cache-from: type=registry,ref=authorizon/opal-server:latest
+          cache-to: type=inline
+          load: true
+          tags: |
+            authorizon/opal-server:test
+            authorizon/opal-server:latest
+            authorizon/opal-server:${{ github.event.release.tag_name }}
 
-      - name: Create modified docker compose
+      - name: Create modified docker compose file
         run: sed 's/:latest/:test/g' docker/docker-compose-example.yml > docker/docker-compose-test.yml
 
       - name: Bring up stack
@@ -55,23 +78,6 @@ jobs:
 
       - name: Output container logs
         run: docker-compose -f docker/docker-compose-test.yml logs
-
-  # this job will rebuild and push the docker images to docker hub
-  # - it will only run after a new "release" is create on github
-  # - it will auto tag the image according to the github release tag
-  docker_release:
-    runs-on: ubuntu-latest
-    needs: docker_build_and_test
-    if: github.event_name == 'release' && github.event.action == 'created'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
@asafc This commit goes back to how I implemented it in #62. If you prefer to split testing and release in different stage I can split that but this would mean building images twice, here they are reused.