### PR TITLE
Support OPA authentication with bearer token

### DIFF
--- a/opal_client/config.py
+++ b/opal_client/config.py
@@ -27,6 +27,7 @@ class OpalClientConfig(Confi):
     # opa client (policy store) configuration
     POLICY_STORE_TYPE = confi.enum("POLICY_STORE_TYPE", PolicyStoreTypes, PolicyStoreTypes.OPA)
     POLICY_STORE_URL = confi.str("POLICY_STORE_URL", f"http://localhost:8181/v1")
+    POLICY_STORE_AUTH_TOKEN = confi.str("POLICY_STORE_AUTH_TOKEN", None, description="the authentication (bearer) token OPAL client will use to authenticate against the policy store (i.e: OPA agent)")
     # create an instance of a policy store upon load
 
     def load_policy_store():

--- a/opal_client/opa/options.py
+++ b/opal_client/opa/options.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, List
 from pydantic import BaseModel, Field
 
 class LogLevel(str, Enum):
@@ -37,6 +37,7 @@ class OpaServerOptions(BaseModel):
     tls_cert_file: Optional[str] = Field(None, description="path of TLS certificate file")
     tls_private_key_file: Optional[str] = Field(None, description="path of TLS private key file")
     log_level: LogLevel = Field(LogLevel.info, description="log level for opa logs")
+    files: Optional[List[str]] = Field(None, description="list of built-in rego policies and data.json files that must be loaded into OPA on startup. e.g: system.authz policy when using --authorization=basic, see: https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization")
 
     class Config:
         use_enum_values = True
@@ -53,4 +54,11 @@ class OpaServerOptions(BaseModel):
         """
         returns a dict that can be passed to the OPA cli
         """
-        return self.dict(exclude_none=True, by_alias=True)
+        return self.dict(exclude_none=True, by_alias=True, exclude={'files'})
+
+    def get_opa_startup_files(self) -> str:
+        """
+        returns a list of startup policies and data
+        """
+        files = self.files if self.files is not None else []
+        return " ".join(files)

--- a/opal_client/opa/runner.py
+++ b/opal_client/opa/runner.py
@@ -86,7 +86,8 @@ class OpaRunner:
     def command(self):
         opts = self._options.get_cli_options_dict()
         opts_string = ' '.join([f"{k}={v}" for k,v in opts.items()])
-        return f"opa run --server {opts_string}"
+        startup_files = self._options.get_opa_startup_files()
+        return f"opa run --server {opts_string} {startup_files}".strip()
 
     def _terminate_opa(self):
         logger.info("Stopping OPA")

--- a/opal_client/policy_store/policy_store_client_factory.py
+++ b/opal_client/policy_store/policy_store_client_factory.py
@@ -1,5 +1,5 @@
 
-from typing import Dict
+from typing import Dict, Optional
 from opal_client.policy_store.base_policy_store_client import BasePolicyStoreClient
 from opal_client.config import opal_client_config, PolicyStoreTypes
 
@@ -17,7 +17,7 @@ class PolicyStoreClientFactory:
     CACHE: Dict[str,BasePolicyStoreClient] = {}
 
     @classmethod
-    def get(cls,store_type: PolicyStoreTypes = None, url: str = None, save_to_cache=True) -> BasePolicyStoreClient:
+    def get(cls,store_type: PolicyStoreTypes = None, url: str = None, save_to_cache=True, token:Optional[str]=None) -> BasePolicyStoreClient:
         """Same as self.create() but with caching
 
         Args:
@@ -35,12 +35,12 @@ class PolicyStoreClientFactory:
         key = cls.get_cache_key(store_type,url)
         value = cls.CACHE.get(key, None)
         if value is None:
-            return cls.create(store_type,url)
+            return cls.create(store_type,url, token)
         else:
             return value
 
     @classmethod
-    def create(cls, store_type: PolicyStoreTypes = None, url: str = None, save_to_cache=True) -> BasePolicyStoreClient:
+    def create(cls, store_type: PolicyStoreTypes = None, url: str = None, save_to_cache=True, token:Optional[str]=None) -> BasePolicyStoreClient:
         """
         Factory method - create a new policy store by type.
 
@@ -58,11 +58,12 @@ class PolicyStoreClientFactory:
         # load defaults
         store_type = store_type or opal_client_config.POLICY_STORE_TYPE
         url = url or opal_client_config.POLICY_STORE_URL
+        store_token = token or opal_client_config.POLICY_STORE_AUTH_TOKEN
 
         # OPA
         if PolicyStoreTypes.OPA == store_type:
             from opal_client.policy_store.opa_client import OpaClient
-            res = OpaClient(url)
+            res = OpaClient(url, opa_auth_token=store_token)
         # MOCK
         elif PolicyStoreTypes.MOCK == store_type:
             from opal_client.policy_store.mock_policy_store_client import MockPolicyStoreClient


### PR DESCRIPTION
# TL;DR
in order to run OPA with authentication check (i.e: not everyone are allowed to access REST API), one should provide the following env vars:
```
OPAL_POLICY_STORE_AUTH_TOKEN=secret
OPAL_INLINE_OPA_CONFIG='{"authorization":"basic","authentication":"token","files":["basic-authz.rego"]}'
```

### 1) Causing inline OPA to only allow requests with bearer tokens
`OPAL_INLINE_OPA_CONFIG` is the options used to start the OPA agent when running with inline OPA. In order to activate OPA authentication at all, one should pass the following settings via this env var:

1) `authentication=token` (the authentication scheme - bearer token authentication.
2) `authorization=basic` (activates the `system.authz` policy to authenticate OPA requests
3) `files`: a list of (policy, static data) modules to load when first starting OPA, each such module must be a file available to OPAL (so if running with docker containers, one must use docker volumes).

At least one of the policy modules must contain a policy with package name `system.authz`.
See full example with OPA documentation: https://www.openpolicyagent.org/docs/latest/security/#authentication-and-authorization

#### Example OPA authentication policy
```
package system.authz

default allow = false           # Reject requests by default.

allow {                         # Allow request if...
    "secret" == input.identity  # Identity is the secret root key.
}
```

if using this policy - only HTTP request with the Bearer token "secret" will be allowed, but this can be extended to any kind of token, can be a JWT, etc.

### 2) Making OPAL client pass the correct token to connect to the OPA agent
`OPAL_POLICY_STORE_AUTH_TOKEN` is the authentication (bearer) token OPAL client will use to authenticate against the policy store (i.e: OPA agent).