### PR TITLE
Fix requesting client token

### DIFF
--- a/opal_common/cli/commands.py
+++ b/opal_common/cli/commands.py
@@ -53,7 +53,7 @@ def obtain_token(
     async def fetch():
         async with ClientSession(headers={"Authorization": f"bearer {master_token}"}) as session:
             details = AccessTokenRequest(type=type, ttl=ttl, claims=claims).json()
-            res = await session.post(server_url, data=details)
+            res = await session.post(server_url, data=details, headers={'content-type': 'application/json'})
             data = await res.json()
             if just_the_token:
                 return data["token"]


### PR DESCRIPTION
The error from https://github.com/authorizon/opal/issues/102 also applies to users of the CLI, who currently cannot request client tokens.