### PR TITLE
Repo Cloner fixes

### DIFF
--- a/opal_common/git/repo_cloner.py
+++ b/opal_common/git/repo_cloner.py
@@ -74,6 +74,7 @@ class RepoCloner:
         self,
         repo_url: str,
         clone_path: str,
+        branch_name: str = "master",
         retry_config = None,
         ssh_key: Optional[str] = None,
         ssh_key_file_path: Optional[str] = None,
@@ -90,10 +91,11 @@ class RepoCloner:
         """
         if repo_url is None:
             raise ValueError("must provide repo url!")
-        
+
 
         self.url = repo_url
         self.path = os.path.expanduser(clone_path)
+        self.branch_name = branch_name
         self._ssh_key = ssh_key
         self._ssh_key_file_path = ssh_key_file_path or opal_common_config.GIT_SSH_KEY_FILE
         self._retry_config = retry_config if retry_config is not None else self.DEFAULT_RETRY_CONFIG
@@ -130,7 +132,7 @@ class RepoCloner:
         clones the repo from url or throws GitFailed
         """
         env = self._provide_git_ssh_environment()
-        _clone_func = partial(Repo.clone_from, url=self.url, to_path=self.path, env=env)
+        _clone_func = partial(Repo.clone_from, url=self.url, to_path=self.path, branch=self.branch_name, env=env)
         _clone_with_retries = retry(**self._retry_config)(_clone_func)
         try:
             repo = _clone_with_retries()

--- a/opal_common/git/repo_cloner.py
+++ b/opal_common/git/repo_cloner.py
@@ -1,9 +1,11 @@
 import os
+import shutil
+import asyncio
 
 from functools import partial
 from typing import Optional
 from pathlib import Path
-from tenacity import retry, wait_fixed, stop_after_attempt, RetryError
+from tenacity import retry, wait, stop, RetryError
 from git import Repo, GitError, GitCommandError
 
 from opal_common.logger import logger
@@ -64,10 +66,9 @@ class RepoCloner:
     the repo already existing on the filesystem.
     """
 
+    # wait indefinitely until successful
     DEFAULT_RETRY_CONFIG = {
-        'wait': wait_fixed(5),
-        'stop': stop_after_attempt(2),
-        'reraise': True,
+        'wait': wait.wait_random_exponential(multiplier=0.5, max=30),
     }
 
     def __init__(
@@ -78,6 +79,7 @@ class RepoCloner:
         retry_config = None,
         ssh_key: Optional[str] = None,
         ssh_key_file_path: Optional[str] = None,
+        clone_timeout: int = 0,
     ):
         """inits the repo cloner.
 
@@ -99,8 +101,10 @@ class RepoCloner:
         self._ssh_key = ssh_key
         self._ssh_key_file_path = ssh_key_file_path or opal_common_config.GIT_SSH_KEY_FILE
         self._retry_config = retry_config if retry_config is not None else self.DEFAULT_RETRY_CONFIG
+        if clone_timeout > 0:
+            self._retry_config.update({'stop': stop.stop_after_delay(clone_timeout)})
 
-    def clone(self) -> CloneResult:
+    async def clone(self) -> CloneResult:
         """
         initializes a git.Repo and returns the clone result.
         it either:
@@ -108,36 +112,40 @@ class RepoCloner:
             - finds a cloned repo locally and does not clone from remote.
         """
         logger.info("Cloning repo from '{url}' to '{to_path}'", url=self.url, to_path=self.path)
-        git_path = Path(self.path) / Path(".git")
-        if git_path.exists():
-            return self._attempt_init_from_local_repo()
-        else:
-            return self._attempt_clone_from_url()
+        self._discard_previous_local_clone()
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._attempt_clone_from_url)
 
-    def _attempt_init_from_local_repo(self) -> CloneResult:
+    def _discard_previous_local_clone(self):
         """
         inits the repo from local .git or throws GitFailed
         """
-        logger.info("Repo already exists in '{repo_path}'", repo_path=self.path)
-        try:
-            repo = Repo(self.path)
-        except Exception as e:
-            logger.exception("cannot init local repo: {error}", error=e)
-            raise GitFailed(e)
+        git_path = Path(self.path) / Path(".git")
+        if not git_path.exists():
+            return
 
-        return LocalClone(repo)
+        dst_path = "{}.old".format(str(Path(self.path)))
+        i = 0
+        while Path(dst_path + str(i)).exists():
+            i += 1
+        dst_path = dst_path + str(i)
+
+        logger.info(f"Repo already exists in '{self.path}', moving previous clone to '{dst_path}'")
+        try:
+            shutil.move(self.path, dst_path)
+        except Exception as e:
+            logger.error(f"could not move previous clone, got error: {e}")
 
     def _attempt_clone_from_url(self) -> CloneResult:
         """
         clones the repo from url or throws GitFailed
         """
         env = self._provide_git_ssh_environment()
-        _clone_func = partial(Repo.clone_from, url=self.url, to_path=self.path, branch=self.branch_name, env=env)
+        _clone_func = partial(self._clone, env=env)
         _clone_with_retries = retry(**self._retry_config)(_clone_func)
         try:
-            repo = _clone_with_retries()
+            repo: Repo = _clone_with_retries()
         except (GitError, GitCommandError) as e:
-            logger.exception("cannot clone policy repo: {error}", error=e)
             raise GitFailed(e)
         except RetryError as e:
             logger.exception("cannot clone policy repo: {error}", error=e)
@@ -145,6 +153,13 @@ class RepoCloner:
         else:
             logger.info("Clone succeeded", repo_path=self.path)
             return RemoteClone(repo)
+
+    def _clone(self, env) -> Repo:
+        try:
+            return Repo.clone_from(url=self.url, to_path=self.path, branch=self.branch_name, env=env)
+        except (GitError, GitCommandError) as e:
+            logger.error("cannot clone policy repo: {error}", error=e)
+            raise
 
     def _provide_git_ssh_environment(self):
         """

--- a/opal_common/git/repo_watcher.py
+++ b/opal_common/git/repo_watcher.py
@@ -30,8 +30,9 @@ class RepoWatcher:
         remote_name: str = "origin",
         ssh_key: Optional[str] = None,
         polling_interval: int = 0,
+        clone_timeout: int = 0,
     ):
-        self._cloner = RepoCloner(repo_url, clone_path, branch_name=branch_name, ssh_key=ssh_key)
+        self._cloner = RepoCloner(repo_url, clone_path, branch_name=branch_name, ssh_key=ssh_key, clone_timeout=clone_timeout)
         self._branch_name = branch_name
         self._remote_name = remote_name
         self._tracker = None
@@ -60,7 +61,7 @@ class RepoWatcher:
         clones the repo and potentially starts the polling task
         """
         try:
-            result = self._cloner.clone()
+            result = await self._cloner.clone()
         except GitFailed as e:
             await self._on_git_failed(e)
             return

--- a/opal_common/git/repo_watcher.py
+++ b/opal_common/git/repo_watcher.py
@@ -31,7 +31,7 @@ class RepoWatcher:
         ssh_key: Optional[str] = None,
         polling_interval: int = 0,
     ):
-        self._cloner = RepoCloner(repo_url, clone_path, ssh_key=ssh_key)
+        self._cloner = RepoCloner(repo_url, clone_path, branch_name=branch_name, ssh_key=ssh_key)
         self._branch_name = branch_name
         self._remote_name = remote_name
         self._tracker = None

--- a/opal_common/git/tests/repo_watcher_test.py
+++ b/opal_common/git/tests/repo_watcher_test.py
@@ -48,7 +48,8 @@ async def test_repo_watcher_git_failed_callback(tmp_path):
     # configure the watcher to watch an invalid repo
     watcher = RepoWatcher(
         repo_url=INVALID_REPO_REMOTE_URL,
-        clone_path=target_path
+        clone_path=target_path,
+        clone_timeout=3,
     )
     # configure the error callback
     watcher.on_git_failed(failure_callback)
@@ -85,9 +86,9 @@ async def test_repo_watcher_detect_new_commits_with_manual_trigger(
     target_path: Path = Path(repo.working_tree_dir)
 
     # configure the watcher with a valid local repo (our test repo)
-    # the returned repo will track the test remote, not a real remote
+    # the returned repo will track the local remote repo
     watcher = RepoWatcher(
-        repo_url=VALID_REPO_REMOTE_URL_HTTPS,
+        repo_url=remote_repo.working_tree_dir,
         clone_path=target_path
     )
     # configure the error callback
@@ -157,7 +158,7 @@ async def test_repo_watcher_detect_new_commits_with_polling(
     # configure the watcher with a valid local repo (our test repo)
     # the returned repo will track the test remote, not a real remote
     watcher = RepoWatcher(
-        repo_url=VALID_REPO_REMOTE_URL_HTTPS,
+        repo_url=remote_repo.working_tree_dir,
         clone_path=target_path,
         polling_interval=3 # every 3 seconds do a pull to try and detect changes
     )

--- a/opal_server/config.py
+++ b/opal_server/config.py
@@ -57,6 +57,7 @@ class OpalServerConfig(Confi):
     POLICY_REPO_MAIN_REMOTE = confi.str("POLICY_REPO_MAIN_REMOTE", "origin")
     POLICY_REPO_SSH_KEY = confi.str("POLICY_REPO_SSH_KEY", None)
     POLICY_REPO_MANIFEST_PATH = confi.str("POLICY_REPO_MANIFEST_PATH", ".manifest")
+    POLICY_REPO_CLONE_TIMEOUT = confi.int("POLICY_REPO_CLONE_TIMEOUT", 0) # if 0, waits forever until successful clone
     LEADER_LOCK_FILE_PATH = confi.str("LEADER_LOCK_FILE_PATH", "/tmp/opal_server_leader.lock")
 
     REPO_WATCHER_ENABLED = confi.bool("REPO_WATCHER_ENABLED", True)

--- a/opal_server/policy/watcher/factory.py
+++ b/opal_server/policy/watcher/factory.py
@@ -18,6 +18,7 @@ def setup_watcher_task(
     remote_name: str = None,
     ssh_key: Optional[str] = None,
     polling_interval: int = None,
+    clone_timeout: int = None,
     extensions: Optional[List[str]] = None,
 ) -> RepoWatcherTask:
     # load defaults
@@ -27,6 +28,7 @@ def setup_watcher_task(
     remote_name = remote_name or opal_server_config.POLICY_REPO_MAIN_REMOTE
     ssh_key = ssh_key or opal_server_config.POLICY_REPO_SSH_KEY
     polling_interval = polling_interval or opal_server_config.POLICY_REPO_POLLING_INTERVAL
+    clone_timeout = clone_timeout or opal_server_config.POLICY_REPO_CLONE_TIMEOUT
     extensions = extensions if extensions is not None else opal_server_config.OPA_FILE_EXTENSIONS
     watcher = RepoWatcher(
         repo_url=repo_url,
@@ -35,6 +37,7 @@ def setup_watcher_task(
         remote_name=remote_name,
         ssh_key=ssh_key,
         polling_interval=polling_interval,
+        clone_timeout=clone_timeout
     )
     watcher.on_new_commits(
         partial(

--- a/opal_server/policy/watcher/task.py
+++ b/opal_server/policy/watcher/task.py
@@ -1,3 +1,7 @@
+
+import os
+import signal
+
 import asyncio
 from typing import List, Optional, Coroutine
 
@@ -72,4 +76,6 @@ class RepoWatcherTask:
         called when the watcher fails, and stops all tasks gracefully
         """
         logger.error("watcher failed with exception: {err}", err=repr(exc))
-        await self.stop()
+        self.signal_stop()
+        # trigger uvicorn graceful shutdown
+        os.kill(os.getpid(), signal.SIGTERM)


### PR DESCRIPTION
changed a few things in how the repo cloner works:
- It tries indefinitely to clone the repo (i.e: resilient to temp network errors) - fixes #111 
- Indefinite wait for successful clone can be cancelled with new Env var: `OPAL_POLICY_REPO_CLONE_TIMEOUT`
- previous local clones are discarded - this should not affect running docker (unless using a volume) but it does affect running opal as a library.
- fixed cloning remote branches who are not master - they are now cloned correctly
- repo cloner is now running in asyncio executor thread - until initial successful clone, `/policy` (bundle) api correctly return 503.