### PR TITLE
Add broadcaster keepalive task to prevent broadcast backbone from closing the session

### DIFF
--- a/opal_server/config.py
+++ b/opal_server/config.py
@@ -59,6 +59,10 @@ class OpalServerConfig(Confi):
     # publisher
     PUBLISHER_ENABLED = confi.bool("PUBLISHER_ENABLED", True)
 
+    # broadcaster keepalive
+    BROADCAST_KEEPALIVE_INTERVAL = confi.int("BROADCAST_KEEPALIVE_INTERVAL", 3600, description="the time to wait between sending two consecutive broadcaster keepalive messages")
+    BROADCAST_KEEPALIVE_TOPIC = confi.str("BROADCAST_KEEPALIVE_TOPIC", "__broadcast_session_keepalive__", description="the topic on which we should send broadcaster keepalive messages")
+
     # Data updates
     ALL_DATA_TOPIC = confi.str("ALL_DATA_TOPIC", "policy_data", description="Top level topic for data")
     ALL_DATA_ROUTE = confi.str("ALL_DATA_ROUTE", "/policy-data")

--- a/opal_server/publisher.py
+++ b/opal_server/publisher.py
@@ -1,13 +1,14 @@
-from typing import Optional, Any
-
-from fastapi_websocket_pubsub.pub_sub_client import PubSubClient
+from fastapi_websocket_pubsub import Topic, PubSubClient
 from opal_common.confi.confi import load_conf_if_none
 from opal_common.utils import get_authorization_header
-from opal_common.topics.publisher import TopicPublisher, ClientSideTopicPublisher
+from opal_common.topics.publisher import (
+    TopicPublisher,
+    PeriodicPublisher,
+    ServerSideTopicPublisher,
+    ClientSideTopicPublisher
+)
 from opal_server.config import opal_server_config
 
-
-publisher = None
 
 def setup_publisher_task(
     server_uri: str = None,
@@ -21,3 +22,15 @@ def setup_publisher_task(
         ),
         server_uri=server_uri,
     )
+
+
+def setup_broadcaster_keepalive_task(
+    publisher: ServerSideTopicPublisher,
+    time_interval: int,
+    topic: Topic = '__broadcast_session_keepalive__'
+) -> PeriodicPublisher:
+    """
+    a periodic publisher with the intent to trigger messages on the broadcast channel,
+    so that the session to the backbone won't become idle and close on the backbone end.
+    """
+    return PeriodicPublisher(publisher, time_interval, topic, task_name='broadcaster keepalive task')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ aiohttp
 broadcaster[postgres]
 colorama
 fastapi==0.65.2
-fastapi_websocket_pubsub>=0.1.19
-fastapi_websocket_rpc>=0.1.20
+fastapi_websocket_pubsub>=0.1.20
+fastapi_websocket_rpc>=0.1.21
 GitPython
 gunicorn
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiohttp
 broadcaster[postgres]
 colorama
 fastapi==0.65.2
-fastapi_websocket_pubsub>=0.1.20
+fastapi_websocket_pubsub>=0.1.21
 fastapi_websocket_rpc>=0.1.21
 GitPython
 gunicorn


### PR DESCRIPTION
We have seen a behavior in our demo environment - where Postgres closes a db session used for broadcaster notifications after no messages were broadcasted for several days. 

We are adding a safeguard here (a keepalive task) so that if in a live environment there is no traffic for a long period of time - the session will be kept alive due to the keepalive messages triggering a NOTIFY event, which in turn will also keep the LISTEN sessions alive due to traffic going through.