### PR TITLE
Add example compose secure mode

### DIFF
--- a/docker/docker-compose-with-security.yml
+++ b/docker/docker-compose-with-security.yml
@@ -1,5 +1,5 @@
-# this docker compose file is relying on external environment variables
-# run it using the script file
+# this docker compose file is relying on external environment variables!
+# run it by running the script: ./run-example-with-security.sh
 version: "3.8"
 services:
   # When scaling the opal-server to multiple nodes and/or multiple workers, we use

--- a/docker/docker-compose-with-security.yml
+++ b/docker/docker-compose-with-security.yml
@@ -1,0 +1,75 @@
+# this docker compose file is relying on external environment variables
+# run it using the script file
+version: "3.8"
+services:
+  # When scaling the opal-server to multiple nodes and/or multiple workers, we use
+  # a *broadcast* channel to sync between all the instances of opal-server.
+  # Under the hood, this channel is implemented by encode/broadcaster (see link below).
+  # At the moment, the broadcast channel can be either: postgresdb, redis or kafka.
+  # The format of the broadcaster URI string (the one we pass to opal server as `OPAL_BROADCAST_URI`) is specified here:
+  # https://github.com/encode/broadcaster#available-backends
+  broadcast_channel:
+    image: postgres:alpine
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  opal_server:
+    # by default we run opal-server from latest official image
+    image: authorizon/opal-server:latest
+    environment:
+      # the broadcast backbone uri used by opal server workers (see comments above for: broadcast_channel)
+      - OPAL_BROADCAST_URI=postgres://postgres:postgres@broadcast_channel:5432/postgres
+      # number of uvicorn workers to run inside the opal-server container
+      - UVICORN_NUM_WORKERS=4
+      # the git repo hosting our policy
+      # - if this repo is not public, you can pass an ssh key via `OPAL_POLICY_REPO_SSH_KEY`)
+      # - the repo we pass in this example is *public* and acts as an example repo with dummy rego policy
+      # - for more info, see: https://github.com/authorizon/opal/blob/master/docs/HOWTO/track_a_git_repo.md
+      - OPAL_POLICY_REPO_URL=https://github.com/authorizon/opal-example-policy-repo
+      # in this example we will use a polling interval of 30 seconds to check for new policy updates (git commits affecting the rego policy).
+      # however, it is better to utilize a git *webhook* to trigger the server to check for changes only when the repo has new commits.
+      # for more info see: https://github.com/authorizon/opal/blob/master/docs/HOWTO/track_a_git_repo.md
+      - OPAL_POLICY_REPO_POLLING_INTERVAL=30
+      # server secure mode
+      # in order to run in "secure mode", meaning OPAL server will authenticate all API requests
+      # by requiring a bearer token containing a valid OPAL JWT (all such JWTs are signed by the
+      # OPAL server), you must provide a public key (used for verifying the JWT signature) and a
+      # private key (used for signing on new JWT tokens).
+      - OPAL_AUTH_PUBLIC_KEY=${OPAL_AUTH_PUBLIC_KEY}
+      - OPAL_AUTH_PRIVATE_KEY=${OPAL_AUTH_PRIVATE_KEY}
+      # the master token is used in only one scenario - when we want to generate a new JWT token.
+      # the /token api endpoint on the OPAL server is the only endpoint that requires the master token.
+      - OPAL_AUTH_MASTER_TOKEN=${OPAL_AUTH_MASTER_TOKEN}
+      # configures from where the opal client should initially fetch data (when it first goes up, after disconnection, etc).
+      # the data sources represents from where the opal clients should get a "complete picture" of the data they need.
+      # after the initial sources are fetched, the client will subscribe only to update notifications sent by the server.
+      # please notice - since we fetch data entries from the OPAL server itself, we need to authenticate to that endpoint
+      # with the client's token (JWT).
+      - OPAL_DATA_CONFIG_SOURCES={"config":{"entries":[{"url":"http://host.docker.internal:7002/policy-data","config":{"headers":{"Authorization":"Bearer ${OPAL_CLIENT_TOKEN}"}},"topics":["policy_data"]}]}}
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+    ports:
+      # exposes opal server on the host machine, you can access the server at: http://localhost:7002
+      - "7002:7002"
+    depends_on:
+      - broadcast_channel
+  opal_client:
+    # by default we run opal-client from latest official image
+    image: authorizon/opal-client:latest
+    environment:
+      - OPAL_SERVER_URL=http://opal_server:7002
+      - OPAL_CLIENT_TOKEN=${OPAL_CLIENT_TOKEN}
+      - OPAL_LOG_FORMAT_INCLUDE_PID=true
+      - OPAL_INLINE_OPA_LOG_FORMAT=http
+    ports:
+      # exposes opal client on the host machine, you can access the client at: http://localhost:7000
+      - "7000:7000"
+      # exposes the OPA agent (being run by OPAL) on the host machine
+      # you can access the OPA api that you know and love at: http://localhost:8181
+      # OPA api docs are at: https://www.openpolicyagent.org/docs/latest/rest-api/
+      - "8181:8181"
+    depends_on:
+      - opal_server
+    # this command is not necessary when deploying OPAL for real, it is simply a trick for dev environments
+    # to make sure that opal-server is already up before starting the client.
+    command: sh -c "/usr/wait-for.sh opal_server:7002 --timeout=20 -- /start.sh"

--- a/docker/run-example-with-security.sh
+++ b/docker/run-example-with-security.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Runs the docker-compose-with-security.yml example with
+# crypto keys configured via environment variables
+#
+# Usage:
+#
+# $ ./run-example-with-security.sh
+#
+
+set -e
+
+if [ ! -f "docker-compose-with-security.yml" ]; then
+   echo "did not find compose file - run this script from the 'docker/' directory under opal root!"
+   exit
+fi
+
+echo "------------------------------------------------------------------"
+echo "This script will run the docker-compose-with-security.yml example"
+echo "configuration, and demonstrates how to correctly generate crypto"
+echo "keys and run OPAL in *secure mode*."
+echo "------------------------------------------------------------------"
+
+echo "generating opal crypto keys..."
+ssh-keygen -q -t rsa -b 4096 -m pem -f opal_crypto_key -N ""
+
+echo "saving crypto keys to env vars and removing temp key files..."
+export OPAL_AUTH_PUBLIC_KEY=`cat opal_crypto_key.pub`
+export OPAL_AUTH_PRIVATE_KEY=`cat opal_crypto_key | tr '\n' '_'`
+rm opal_crypto_key.pub opal_crypto_key
+
+echo "generating master token..."
+export OPAL_AUTH_MASTER_TOKEN=`openssl rand -hex 16`
+
+if ! command -v opal-server &> /dev/null
+then
+    echo "opal-server cli was not found, run: 'pip install opal-server'"
+    exit
+fi
+
+if ! command -v opal-client &> /dev/null
+then
+    echo "opal-client cli was not found, run: 'pip install opal-client'"
+    exit
+fi
+
+echo "running OPAL server so we can sign on JWT tokens..."
+OPAL_REPO_WATCHER_ENABLED=0 opal-server run &
+
+sleep 2;
+
+echo "obtaining client JWT token..."
+export OPAL_CLIENT_TOKEN=`opal-client obtain-token $OPAL_AUTH_MASTER_TOKEN --type client`
+
+echo "killing opal server..."
+ps -ef | grep opal | grep -v grep | awk '{print $2}' | xargs kill
+
+sleep 2;
+
+echo "Saving your config to .env file..."
+rm -f .env
+echo "OPAL_AUTH_PUBLIC_KEY=$OPAL_AUTH_PUBLIC_KEY" >> .env
+echo "OPAL_AUTH_PRIVATE_KEY=$OPAL_AUTH_PRIVATE_KEY" >> .env
+echo "ACALLA_MASTER_TOKEN=$ACALLA_MASTER_TOKEN" >> .env
+
+echo "--------"
+echo "ready to run..."
+echo "--------"
+
+docker compose -f docker-compose-with-security.yml --env-file .env up --force-recreate

--- a/opal_server/server.py
+++ b/opal_server/server.py
@@ -102,7 +102,9 @@ class OpalServer:
                 audience=opal_common_config.AUTH_JWT_AUDIENCE,
                 issuer=opal_common_config.AUTH_JWT_ISSUER,
             )
-        if not self.signer.enabled:
+        if self.signer.enabled:
+            logger.info("OPAL is running in secure mode - will verify API requests with JWT tokens.")
+        else:
             logger.info("OPAL was not provided with JWT encryption keys, cannot verify api requests!")
 
         if enable_jwks_endpoint:


### PR DESCRIPTION
Added an example docker compose configuration so that users may better understand how to turn on OPAL authentication with JWTs (i.e: "secure mode").

In order to run the example:

1) start in OPAL root directory, and cd into the docker directory:
```
cd docker/
```
2) if they are not installed in your python (virtual) environment - install the opal-server and opal-client CLIs:
```
pip install opal-server
pip install opal-client
```

3) run the script:
```
./run-example-with-security.sh
```

you should see the following output (skipped non interesting lines):
```
------------------------------------------------------------------
This script will run the docker-compose-with-security.yml example
configuration, and demonstrates how to correctly generate crypto
keys and run OPAL in *secure mode*.
------------------------------------------------------------------
generating opal crypto keys...
saving crypto keys to env vars and removing temp key files...
generating master token...
running OPAL server so we can sign on JWT tokens...
...
obtaining client JWT token...
2021-11-20T18:39:59.706050+0200 | 95656 | uvicorn.protocols.http.httptools_impl   | INFO  | 127.0.0.1:61957 - "POST /token HTTP/1.1" 200
killing opal server...
...
Saving your config to .env file...
--------
ready to run...
--------
...
[+] Running 3/3
 ⠿ Container docker_broadcast_channel_1  Recreated                                                                                                                                        0.1s
 ⠿ Container docker_opal_server_1        Recreated                                                                                                                                        0.1s
 ⠿ Container docker_opal_client_1        Recreated                                                                                                                                        0.0s
...
... | INFO  | OPAL is running in secure mode - will verify API requests with JWT tokens.
...
... | INFO  | Client connected
... | INFO  | Client connected
```

The line **OPAL is running in secure mode - will verify API requests with JWT tokens.** means that the crypto keys needed for JWT verification and signing are successfully loaded into OPAL - and it can verify API requests authenticated with JWTs.

The lines **Client connected** means that the OPAL client successfully authenticated with its client JWT.