### PR TITLE
fix bug where changes to different directories in the same commit are ignored

### DIFF
--- a/opal_common/schemas/policy.py
+++ b/opal_common/schemas/policy.py
@@ -27,3 +27,8 @@ class PolicyBundle(BaseSchema):
     data_modules: List[DataModule]
     policy_modules: List[RegoModule]
     deleted_files: Optional[DeletedFiles]
+
+class PolicyUpdateMessage(BaseModel):
+    old_policy_hash: str
+    new_policy_hash: str
+    changed_directories: List[str]

--- a/opal_server/policy/watcher/callbacks.py
+++ b/opal_server/policy/watcher/callbacks.py
@@ -7,6 +7,7 @@ from opal_common.paths import PathUtils
 from opal_common.logger import logger
 from opal_common.git.commit_viewer import CommitViewer, has_extension
 from opal_common.git.diff_viewer import DiffViewer
+from opal_common.schemas.policy import PolicyUpdateMessage
 from opal_common.topics.publisher import TopicPublisher
 from opal_common.topics.utils import policy_topics
 
@@ -27,7 +28,12 @@ async def publish_all_directories_in_repo(
         directories = PathUtils.intermediate_directories(all_paths)
         logger.info("Publishing policy update, directories: {directories}", directories=[str(d) for d in directories])
         topics = policy_topics(directories)
-        publisher.publish(topics=topics, data=new_commit.hexsha)
+        message = PolicyUpdateMessage(
+            old_policy_hash=old_commit.hexsha,
+            new_policy_hash=new_commit.hexsha,
+            changed_directories=[str(path) for path in directories]
+        )
+        publisher.publish(topics=topics, data=message.dict())
 
 
 async def publish_changed_directories(
@@ -64,4 +70,9 @@ async def publish_changed_directories(
         directories = PathUtils.intermediate_directories(all_paths)
         logger.info("Publishing policy update, directories: {directories}", directories=[str(d) for d in directories])
         topics = policy_topics(directories)
-        publisher.publish(topics=topics, data=new_commit.hexsha)
+        message = PolicyUpdateMessage(
+            old_policy_hash=old_commit.hexsha,
+            new_policy_hash=new_commit.hexsha,
+            changed_directories=[str(path) for path in directories]
+        )
+        publisher.publish(topics=topics, data=message.dict())


### PR DESCRIPTION
This fixes #180

### The root cause
1) when we publish a change to multiple topics at once - the pub/sub library will always publish to each topic separately.

in other words: `publish(topics=["dir1", "dir2", data=hash1]` will result in two messages sent by opal server:
```
message1 = {topic="dir1", data=hash1}
message2 = {topic="dir2", data=hash1}
```

2) The client will only fetch dir1 when receiving the first message - but it will bump the latest known hash to hash1.

3) The client will do nothing for the second message, because it already thinks it has that hash (hash1).

### Possible solutions
There are two possible solutions (both of them are breaking changes - but not to users - only to the on-wire protocol).
1) publish the entire context as the message data - which is the solution i took here.
2) ignore the "latest known hash" in the policy store, and instead go with the "latest known hash" of the update message - this solution also requires us to do the same changes to the policy update message. However i tend to like it less because the "diff" to the policy store is now not atomic (i,e: all changes at once).